### PR TITLE
Update PolicyExceptions to v2beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update PolicyExceptions to v2 and fallback to v2beta1.
+
 ## [0.2.0] - 2024-01-18
 
 ## Changed

--- a/helm/pyroscope/templates/kyverno-policy-exceptions.yaml
+++ b/helm/pyroscope/templates/kyverno-policy-exceptions.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.kyvernoPolicyExceptions.enabled }}
+{{ if .Capabilities.APIVersions.Has "kyverno.io/v2/PolicyException" -}}
+apiVersion: kyverno.io/v2
+{{- else }}
 apiVersion: kyverno.io/v2beta1
+{{- end }}
 kind: PolicyException
 metadata:
   annotations: 

--- a/helm/pyroscope/templates/kyverno-policy-exceptions.yaml
+++ b/helm/pyroscope/templates/kyverno-policy-exceptions.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.kyvernoPolicyExceptions.enabled }}
-apiVersion: kyverno.io/v2alpha1
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   annotations: 


### PR DESCRIPTION
### Related issue: https://github.com/giantswarm/giantswarm/issues/30726

## Description

We need to update the PolicyExceptions apiVersion to v2beta1 as v2alpha1 is being removed in the next Kyverno release.