### PR TITLE
fix: fix ABS override_app_version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ workflows:
           app_catalog_test: giantswarm-playground-test-catalog
           ct_config: ".circleci/ct-config.yaml"
           chart: "pyroscope"
+          override_app_version: false
           # Trigger job on git tag.
           filters:
             tags:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change team annotation in `Chart.yaml` to OpenContainers format (`io.giantswarm.application.team`).
 - Update PolicyExceptions to v2 and fallback to v2beta1.
+- Fix ABS config to not override AppVersion in Chart.yaml
 
 ## [0.2.0] - 2024-01-18
 


### PR DESCRIPTION
In recent versions, ABS and architect orb changed the default behaviour for overriding the AppVersion in Chart.yaml when building and pushing charts. Now the default is to override it.
This does not work for this chart, since we use an upstream image with a different version than the chart itself.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
